### PR TITLE
Renaming command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+go.mod
+go.sum
 goblocks
 addr_index
 CMakeLists.txt

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,8 +53,8 @@ func init() {
 	rootCmd.PersistentFlags().String("cachePath", "", "The location of TrueBlocks' cache")
 	rootCmd.PersistentFlags().IntP("startBlock", "s", -1, "First block to visit")
 	rootCmd.PersistentFlags().IntP("nBlocks", "n", 5000, "The number of blocks to scrape during this invocation")
-	rootCmd.PersistentFlags().IntP("nBlockProcesses", "", 50, "The number of block processor go routines to create")
-	rootCmd.PersistentFlags().IntP("nAddrProcesses", "", 100, "The number of address processor go routines to create")
+	rootCmd.PersistentFlags().IntP("nBlockProcs", "", 50, "The number of block processor go routines to create")
+	rootCmd.PersistentFlags().IntP("nAddrProcs", "", 100, "The number of address processor go routines to create")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -91,7 +91,7 @@ func initConfig() {
 	viper.BindPFlag("settings.cachePath", rootCmd.PersistentFlags().Lookup("cachePath"))
 	viper.BindPFlag("startBlock", rootCmd.PersistentFlags().Lookup("startBlock"))
 	viper.BindPFlag("nBlocks", rootCmd.PersistentFlags().Lookup("nBlocks"))
-	viper.BindPFlag("nBlockProcesses", rootCmd.PersistentFlags().Lookup("nBlockProcesses"))
-	viper.BindPFlag("nAddrProcesses", rootCmd.PersistentFlags().Lookup("nAddrProcesses"))
+	viper.BindPFlag("nBlockProcs", rootCmd.PersistentFlags().Lookup("nBlockProcs"))
+	viper.BindPFlag("nAddrProcs", rootCmd.PersistentFlags().Lookup("nAddrProcs"))
 	viper.SetEnvKeyReplacer(strings.NewReplacer("SETTINGS.", ""))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,14 +25,13 @@ var rootCmd = &cobra.Command{
 	Short: "Build, query, or share an index of Ethereum addresses per block",
 	Long: `
 Description:
-  Blaze watches the front edge of the Ethereum blockchain and accumulates a
-  list of every addresses as it appears anywhere on the chain. You may query
-  this index to produce a list of <blockNumber,transactionId> pairs many orders
-  of magnitude faster than querying the blockchain directly. Armed with this
-  list of pairs, you may then call "acctExport" to detail the full transaction
-  history for any account including external and internal transactions, logs,
-  and traces. Blaze also allows you to seed (share the index) or leech (retrieve
-  the index from others) via IPFS.`,
+  Blaze watches the front edge of the blockchain and accumulates a list
+  of every addresses as it appears anywhere on the chain. You may query
+  this index many orders of magnitude faster than querying the blockchain
+  directly. The query produces a list of <blk,tx_id> pairs. Armed with this
+  list of pairs, you may then call "acctExport" which produces the full
+  transactionhistory for any account including external transactions, 
+  message calls, logs, and traces.`,
 	Version: "GHC-TrueBlocks, LLC//0.0.1-alpha",
 }
 

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"bytes"
-//	"encoding/csv"
+	//	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
-//	"path/filepath"
+
+	//	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -447,20 +448,20 @@ func writeAddresses(blockNum string, addressMap map[string]bool) {
 	counter = counter + 1
 }
 
-func processBlocks(startBlock int, numBlocks int, skip int, nBlockProcesses int, nAddressProcesses int) {
+func processBlocks(startBlock int, numBlocks int, skip int, nBlockProcs int, nAddrProcs int) {
 
 	blockChannel := make(chan int)
 	addressChannel := make(chan BlockInternals)
 
 	var blockWG sync.WaitGroup
-	blockWG.Add(nBlockProcesses)
-	for i := 0; i < nBlockProcesses; i++ {
+	blockWG.Add(nBlockProcs)
+	for i := 0; i < nBlockProcs; i++ {
 		go getTracesAndLogs(blockChannel, addressChannel, &blockWG)
 	}
 
 	var addressWG sync.WaitGroup
-	addressWG.Add(nAddressProcesses)
-	for i := 0; i < nAddressProcesses; i++ {
+	addressWG.Add(nAddrProcs)
+	for i := 0; i < nAddrProcs; i++ {
 		go extractAddresses(addressChannel, &addressWG)
 	}
 
@@ -547,7 +548,6 @@ func goodAddr(addr string) bool {
 	// As per EIP 1352, all addresses less than the following value are reserved
 	// for pre-compiles. We don't index precompiles.
 	if addr < "0x000000000000000000000000000000000000ffff" {
-		//	if addr < "0x0000000000000000000000000000000000000009" {
 		return false
 	}
 	return true
@@ -592,21 +592,18 @@ Description:
 		}
 		n := viper.GetInt("nBlocks")
 		skip := 1
-		nBlockProcesses := viper.GetInt("nBlockProcesses")
-		nAddrProcesses := viper.GetInt("nAddrProcesses")
+		nBlockProcs := viper.GetInt("nBlockProcs")
+		nAddrProcs := viper.GetInt("nAddrProcs")
 		//		fmt.Println("rpcProvider: ", viper.GetString("settings.rpcProvider"))
 		//		fmt.Println("cachePath: ", viper.GetString("settings.cachePath"))
 		//		fmt.Println("startBlock: ", start)
 		//		fmt.Println("nBlocks: ", n)
-		//      fmt.Println("nBlockChains: ", nBlockProcesses)
-		//      fmt.Println("nAddrProcesses: ", nAddrProcesses)
-		processBlocks(start, n, skip, nBlockProcesses, nAddrProcesses)
+		//      fmt.Println("nBlockProcs: ", nBlockProcs)
+		//      fmt.Println("nAddrProcs: ", nAddrProcs)
+		processBlocks(start, n, skip, nBlockProcs, nAddrProcs)
 	},
 }
 
-var maxBlocks int
-
 func init() {
 	rootCmd.AddCommand(scrapeCmd)
-	scrapeCmd.PersistentFlags().IntVarP(&maxBlocks, "maxBlocks", "m", 0, "The maximum number of blocks to scrape (default is to catch up).")
 }


### PR DESCRIPTION
Renamed `nBlockProcesses` and nAddrProcesses` to `nBlockProcs` and `nAddrProcs` to be a bit less verbose. Also, removed unused varaible `maxBlocks`. Added two items specific to TB build to `.gitignore`.